### PR TITLE
Fix validate schema

### DIFF
--- a/src/label.test.ts
+++ b/src/label.test.ts
@@ -1,14 +1,56 @@
-import { assertEquals } from "std/testing/asserts.ts";
+import { ObjectSchema, StringSchema } from "inspect/mod.ts";
+import { assertEquals, assertThrows } from "std/testing/asserts.ts";
 import { Label } from "./label.ts";
 
-Deno.test("Cargo Label: Should throw 'Not setup' error'", () => {
-  assertEquals(
-    new Label({
-      labels: {
-        name: "Hello",
-        value: 2,
+Deno.test(Label.name, async (t) => {
+  await t.step("should equals undefined", () => {
+    assertEquals(
+      new Label<any>({
+        labels: {
+          name: "Hello",
+        },
+      }).get("value"),
+      undefined,
+    );
+  });
+
+  await t.step('should equals "Luke"', () => {
+    assertEquals(
+      new Label({
+        labels: {
+          name: "Luke",
+        },
+      }).get("name"),
+      "Luke",
+    );
+  });
+
+  await t.step("should validate schema", () => {
+    assertEquals(
+      new Label({
+        schema: new ObjectSchema({
+          name: new StringSchema(),
+        }),
+        labels: {
+          name: "Luke",
+        },
+      }).get("name"),
+      "Luke",
+    );
+  });
+
+  await t.step("should throw schema validation error", () => {
+    assertThrows(
+      () => {
+        new Label({
+          schema: new ObjectSchema({
+            name: new StringSchema(),
+          }),
+          labels: {},
+        });
       },
-    }).get("value"),
-    2,
-  );
+      Error,
+      '[{"message":"\\"name\\" is required"},{"message":"\\"name\\" is not type \\"string\\""}]',
+    );
+  });
 });

--- a/src/label.ts
+++ b/src/label.ts
@@ -12,9 +12,13 @@ export type Labels = {
 export class Label<T extends Labels> {
   private readonly labels = new Map();
   constructor(options: LabelsOptions<T>) {
-    if (options.schema instanceof ObjectSchema) {
-      options.schema;
+    if (typeof options.schema?.validate === "function") {
+      const { errors } = options.schema.validate(options.labels);
+      if (errors.length) {
+        throw Error(JSON.stringify(errors));
+      }
     }
+
     for (const label in options.labels) {
       this.labels.set(label, options.labels[label]);
     }

--- a/src/parcel/main.ts
+++ b/src/parcel/main.ts
@@ -1,8 +1,11 @@
 import { Label, Labels } from "../mod.ts";
 import { assemble, get } from "assemble/mod.ts";
 
-export function setupLabels(state: Labels) {
-  assemble({ token: "labelOptions", value: state });
+export function setupLabels(options: Labels) {
+  assemble({
+    token: "labelOptions",
+    value: { labels: options },
+  });
   assemble({ class: Label, dependencies: ["labelOptions"] });
   assemble({ token: "LabelService", value: get(Label) });
 }

--- a/src/parcel/plugin.ts
+++ b/src/parcel/plugin.ts
@@ -4,10 +4,10 @@ import { assemble, get } from "assemble/mod.ts";
 export function LabelPlugin<T extends Labels>(options: LabelsOptions<T>) {
   // Setup Label for the server
   assemble({
-    token: "labelConfig",
+    token: "labelOptions",
     value: options,
   });
-  assemble({ class: Label, dependencies: ["labelConfig"] });
+  assemble({ class: Label, dependencies: ["labelOptions"] });
   assemble({ token: "LabelService", value: get(Label) });
 
   const config = <Label<T>> get(Label);


### PR DESCRIPTION
This PR re-introduces the possibility to let label validate a defined schema from Cargo Inspect. The following snipped defines a schema and the labels to validate:

```ts
new Label({
 schema: new ObjectSchema({
    name: new StringSchema(),
  }),
  labels: {
    name: "Luke",
  },
});
```